### PR TITLE
Update aero_misil.py

### DIFF
--- a/aero_misil.py
+++ b/aero_misil.py
@@ -38,44 +38,52 @@ SW_ALETA = .07875  # Superficie de una aleta del AIM (tomado como ref., m2).
 NUM_ALETAS = 4  # Número de aletas.
 SWTOTAL_ALETAS = SW_ALETA * NUM_ALETAS  # Superficie total de aletas (m2).
 
-def coef_resistencia_base_misil(mach):
-    '''Coeficiente de resistencia base del misil.  Varía con el número de Mach.
-    '''
-    if mach < .8:
-        return 0
-    elif mach < 1:
-        x_0 = -1.548523
-        x_1 = 6.05972764
-        x_2 = -7.30548391
-        x_3 = 2.96129532
-        x_4 = 0
-    elif mach < 1.1:
-        x_0 = 5790.90984
-        x_1 = -21984.3314
-        x_2 = 31277.4812
-        x_3 = -19764.4892
-        x_4 = 4680.59822
-    elif mach < 1.5:
-        x_0 = -4.11856506
-        x_1 = 14.2267421
-        x_2 = -16.9678524
-        x_3 = 8.771665
-        x_4 = -1.67398037
-    elif mach < 2.2:
-        x_0 = .30748
-        x_1 = -.13258
-        x_2 = .028812
-        x_3 = 0
-        x_4 = 0
-    elif mach > 2.2:
-        x_0 = .18481
-        x_1 = -.022895
-        x_2 = .0051876
-        x_3 = -.00040742
-        x_4 = 0
-    elif mach > 3.5:
-        return .15
-    return x_4 * mach**4 + x_3 * mach**3 + x_2 * mach**2 + x_1 * mach + x_0
+def coef_resistencia_base_misil(Ml):
+
+	if Ml < 0.8:
+		x0 = 0
+		x1 = 0
+		x2 = 0
+		x3 = 0
+		x4 = 0
+	elif Ml < 1:
+		x0 = -1.548523
+		x1 = 6.05972764
+		x2 = -7.30548391
+		x3 = 2.96129532
+		x4 = 0
+	elif Ml < 1.1:
+		x0 = 5.79090984*10**3
+		x1 = -2.19843314*10**4
+		x2 = 3.12774812*10**4
+		x3 = -1.97644892*10**4
+		x4 = 4.68059822*10**3
+	elif Ml < 1.5:
+		x0 = -4.11856506
+		x1 = 1.42267421*10**1
+		x2 = -1.69678524*10**1
+		x3 = 8.771665
+		x4 = -1.67398037
+	elif Ml < 2.2:
+		x0 = 3.0748*10**-1
+		x1 = -1.3258*10**-1
+		x2 = 2.8812*10**-2
+		x3 = 0
+		x4 = 0
+	elif Ml <=3.5:                            
+		x0 = 1.8481*10**-1
+		x1 = -2.2895*10**-2
+		x2 = 5.1876*10**-3
+		x3 = -4.0742*10**-4
+		x4 = 0
+	elif Ml >3.5:                            
+		x0 = 0.15
+		x1 = 0
+		x2 = 0
+		x3 = 0
+		x4 = 0
+		    		
+	return x4*Ml**4 + x3*Ml**3 + x2*Ml**2 + x1*Ml + x0
 
 def cfcono_misil(re_cono, machl):
     '''Coeficiente de fricción del cono.


### PR DESCRIPTION
Aunque parezca peor escrito, dejadlo así porque si no da error para Mach elevados tal y como estaba antes, así al menos no da errores.
De todas formas hay que verificar el CD a densidades tan bajas ya que se dispara pero como rho se hace casi 0.000000000 la resistencia nos e ve afectada por los CD elevados